### PR TITLE
Multilist with unique IPs

### DIFF
--- a/blocklister/main.py
+++ b/blocklister/main.py
@@ -153,7 +153,7 @@ def get_multiple_lists():
 
     result = render_template(
         "mikrotik_addresslist.jinja2",
-        ips=ips,
+        ips=list(set(ips)),
         listname=listname,
         comment=comment)
     response = make_response(result, 200)


### PR DESCRIPTION
If a multilist contains duplicate IPs, RouterOS will error out with `failure: already have such entry`.
This PR should resolve the issue.